### PR TITLE
[WIP] Make Router.getNearestContacts async

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -4,18 +4,22 @@ var _ = require('lodash');
 var assert = require('assert');
 var constants = require('./constants');
 var Contact = require('./contact');
+var async = require('async');
 
 /**
 * A bucket is a "column" of the routing table. It is an array-like object that
 * holds {@link Contact}s.
 * @constructor
 */
-function Bucket() {
+function Bucket(index, storage) {
   if (!(this instanceof Bucket)) {
     return new Bucket();
   }
-
-  this._contacts = [];
+  assert(_.isNumber(index) && index >= 0 && index <= constants.B);
+  this.index = index;
+  this.contacts = [];
+  this._cache = {};
+  this._setStorageAdapter(storage);
 }
 
 /**
@@ -23,7 +27,7 @@ function Bucket() {
  * @returns {Number}
  */
 Bucket.prototype.getSize = function() {
-  return this._contacts.length;
+  return this.contacts.length;
 };
 
 /**
@@ -31,7 +35,7 @@ Bucket.prototype.getSize = function() {
  * @returns {Array}
  */
 Bucket.prototype.getContactList = function() {
-  return _.clone(this._contacts);
+  return _.clone(_.values(this._cache));
 };
 
 /**
@@ -39,10 +43,14 @@ Bucket.prototype.getContactList = function() {
  * @param {Number} index - Index of contact in bucket
  * @returns {Contact|null}
  */
-Bucket.prototype.getContact = function(index) {
-  assert(index >= 0, 'Contact index cannot be negative');
-
-  return this._contacts[index] || null;
+Bucket.prototype.getContact = function(index, callback) {
+  assert(index >= 0 && index <= constants.B, 'Invalid index');
+  assert(callback instanceof Function);
+  if(this.contacts.length < index) {
+    callback(new Error('Invalid contact index'));
+  } else {
+    this._storage.get(this.contacts[index], callback);
+  }
 };
 
 /**
@@ -50,22 +58,23 @@ Bucket.prototype.getContact = function(index) {
  * @param {Contact} contact - Contact instance to add to bucket
  * @returns {Boolean} added - Indicates whether or not the contact was added
  */
-Bucket.prototype.addContact = function(contact) {
+Bucket.prototype.addContact = function(contact, callback) {
   assert(contact instanceof Contact, 'Invalid contact supplied');
-
+  assert(callback instanceof Function, 'No callback supplied');
+  var self = this;
   if (this.getSize() === constants.K) {
-    return false;
+    return callback(new Error('Bucket full'));
   }
-
-  if (!this.hasContact(contact.nodeID)) {
-    var index = _.sortedIndex(this._contacts, contact, function(contact) {
-      return contact.lastSeen;
+  this._cache[contact.nodeID] = contact;
+  if (!_.includes(self.contacts, contact.nodeID)) {
+    var idx = _.sortedIndex(self.contacts, contact.nodeID, function(nodeID) {
+      return self._cache[nodeID].lastSeen;
     });
-
-    this._contacts.splice(index, 0, contact);
+    self.contacts.splice(idx, 0, contact.nodeID);
+    callback(null, contact);
+  } else {
+    callback(new Error('Contact already in bucket'));
   }
-
-  return true;
 };
 
 /**
@@ -73,15 +82,16 @@ Bucket.prototype.addContact = function(contact) {
  * @param {Contact} contact - Contact instance to remove from bucket
  * @returns {Boolean} removed - Indicates whether or not the contact was removed
  */
-Bucket.prototype.removeContact = function(contact) {
-  var index = this.indexOf(contact);
+Bucket.prototype.removeContact = function(contact, callback) {
+  assert(contact instanceof Contact, 'Invalid contact supplied');
+  assert(callback instanceof Function, 'No callback supplied');
+  var index = _.indexOf(this.contacts, contact.nodeID);
 
   if (index >= 0) {
-    this._contacts.splice(index, 1);
-    return true;
+    this.contacts.splice(index, 1);
+    callback(null, contact);
   }
-
-  return false;
+  callback(new Error('Contact not in bucket'));
 };
 
 /**
@@ -90,13 +100,7 @@ Bucket.prototype.removeContact = function(contact) {
  * @returns {Boolean}
  */
 Bucket.prototype.hasContact = function(nodeID) {
-  for (var i = 0; i < this.getSize(); i++) {
-    if (this._contacts[i].nodeID === nodeID) {
-      return true;
-    }
-  }
-
-  return false;
+  return _.includes(this.contacts, nodeID);
 };
 
 /**
@@ -106,14 +110,92 @@ Bucket.prototype.hasContact = function(nodeID) {
  */
 Bucket.prototype.indexOf = function(contact) {
   assert(contact instanceof Contact, 'Invalid contact supplied');
-
-  for (var i = 0; i < this.getSize(); i++) {
-    if (this.getContact(i).nodeID === contact.nodeID) {
-      return i;
-    }
-  }
-
-  return -1;
+  return _.indexOf(this.contacts, contact.nodeID);
 };
+
+Bucket.prototype.save = function(callback) {
+  assert(callback instanceof Function, 'No callback supplied');
+  var self = this;
+  async.series([
+    this._storage.put.bind(this._storage, 'BUCKET-' + this.index,
+                          this.contacts),
+    function(cb) {
+        self._storage.get('BUCKETS', function(err, results) {
+          if(err || !results) {
+            results = [];
+          }
+          var index = _.indexOf(results, self.index);
+          if(index < 0) {
+            results.push(self.index);
+          }
+          self._storage.put('BUCKETS', results, cb);
+        });
+    }
+  ], function(err) {
+    if(err) {
+      callback(err);
+    } else {
+      callback();
+    }
+  });
+};
+
+Bucket.prototype.load = function(callback) {
+  assert(callback instanceof Function, 'No callback supplied');
+  var self = this;
+  this._storage.get('BUCKET-' + this.index, function(err, contacts) {
+    if(!err && contacts) {
+      self.contacts = contacts;
+    }
+    callback();
+  });
+};
+
+Bucket.prototype.empty = function(callback) {
+  assert(callback instanceof Function, 'No callback supplied');
+  var self = this;
+  async.series([
+    self.load.bind(self),
+    function(cb) {
+      async.each(self.contacts, self._storage.del.bind(self._storage), cb);
+    },
+    self._storage.del.bind(self._storage, 'BUCKET-' + self.index)
+  ], callback);
+};
+
+Bucket.prototype.loadContacts = function(callback) {
+  assert(callback instanceof Function, 'No callback supplied');
+  var self = this;
+  self._cache = {};
+  async.each(self.contacts, function(item, cb) {
+    self._storage.get(item, function(err, result) {
+      if(err || !result) {
+        cb(err);
+      } else {
+        self._cache[result.nodeID] = result;
+        cb();
+      }
+    });
+  }, callback);
+};
+
+/**
+ * Validates the set storage adapter
+ * @private
+ * @param {Object} storage
+ */
+Bucket.prototype._setStorageAdapter = function(storage) {
+  assert(typeof storage === 'object', 'No storage adapter supplied');
+  assert(typeof storage.get === 'function', 'Store has no get method');
+  assert(typeof storage.put === 'function', 'Store has no put method');
+  assert(typeof storage.del === 'function', 'Store has no del method');
+  assert(
+    typeof storage.createReadStream === 'function',
+    'Store has no createReadStream method'
+  );
+
+  this._storage = storage;
+};
+
 
 module.exports = Bucket;

--- a/lib/node.js
+++ b/lib/node.js
@@ -232,35 +232,40 @@ Node.prototype._putValidatedKeyValue = function(item, callback) {
       node._log.info('saving item to local storage');
       return node._storage.put(item.key, JSON.stringify(item), callback);
     }
-
-    if (contacts.length === 0) {
-      node._log.warn('no contacts returned, checking local table...');
-      contacts = node._router.getNearestContacts(
-        item.key,
-        constants.K,
-        node._self.nodeID
-      );
-    }
-
-    node._log.debug('found %d contacts for STORE operation', contacts.length);
-
-    async.each(contacts, function(contact, done) {
-      var message = new Message({
-        method: 'STORE',
-        params: { item: item, contact: node._self }
-      });
-      node._log.debug('sending STORE message to %j', contact);
-      node._rpc.send(contact, message, done);
-    }, function(err) {
-      if (err) {
-        node._log.error(
-          'Failed to store value at one or more nodes, reason:',
-          err.message
+    var getContacts = function(contacts, callback) {
+      if (contacts.length === 0) {
+        node._log.warn('no contacts returned, checking local table...');
+        node._router.getNearestContacts(
+          item.key,
+          constants.K,
+          node._self.nodeID,
+          callback
         );
+      } else {
+        async.setImmediate(function() {
+          callback(null, contacts);
+        });
       }
-
-      // NB: Always store a local copy so we can republish later
-      node._storage.put(item.key, JSON.stringify(item), callback);
+    };
+    getContacts(contacts, function(err, contacts) {
+      node._log.debug('found %d contacts for STORE operation', contacts.length);
+      async.each(contacts, function(contact, done) {
+        var message = new Message({
+          method: 'STORE',
+          params: { item: item, contact: node._self }
+        });
+        node._log.debug('sending STORE message to %j', contact);
+        node._rpc.send(contact, message, done);
+      }, function(err) {
+        if (err) {
+          node._log.error(
+            'Failed to store value at one or more nodes, reason:',
+            err.message
+          );
+        }
+        // NB: Always store a local copy so we can republish later
+        node._storage.put(item.key, JSON.stringify(item), callback);
+      });
     });
   });
 };
@@ -531,23 +536,24 @@ Node.prototype._handleFindNode = function(incomingMsg) {
   var params = incomingMsg.params;
   var contact = this._rpc._createContact(params.contact);
 
-  var near = this._router.getNearestContacts(
+  this._router.getNearestContacts(
     params.key,
     constants.K,
-    params.contact.nodeID
-  );
-
-  var message = new Message({
-    id: incomingMsg.id,
-    result: { nodes: near, contact: node._self }
-  });
-
-  this._log.debug(
-    'sending %s nearest %d contacts',
     params.contact.nodeID,
-    near.length
+    function(err, near) {
+      var message = new Message({
+        id: incomingMsg.id,
+        result: { nodes: near, contact: node._self }
+      });
+
+      node._log.debug(
+        'sending %s nearest %d contacts',
+        params.contact.nodeID,
+        near.length
+      );
+      node._rpc.send(contact, message);
+    }
   );
-  this._rpc.send(contact, message);
 };
 
 /**
@@ -568,20 +574,22 @@ Node.prototype._handleFindValue = function(incomingMsg) {
         'value not found, sending contacts to %s',
         params.contact.nodeID
       );
-
-      var notFoundMessage = new Message({
-        id: incomingMsg.id,
-        result: {
-          nodes: node._router.getNearestContacts(
-            params.key,
-            limit,
-            params.contact.nodeID
-          ),
-          contact: node._self
+      node._router.getNearestContacts(
+        params.key,
+        limit,
+        params.contact.nodeID,
+        function(err, result) {
+          var notFoundMessage = new Message({
+            id: incomingMsg.id,
+            result: {
+              nodes: result,
+              contact: node._self
+            }
+          });
+          node._rpc.send(contact, notFoundMessage);
         }
-      });
-
-      return node._rpc.send(contact, notFoundMessage);
+      );
+      return;
     }
 
     var parsed = JSON.parse(value);

--- a/lib/node.js
+++ b/lib/node.js
@@ -304,17 +304,19 @@ Node.prototype._bindRouterEventHandlers = function() {
   });
 
   function checkRouterStatus(contact) {
-    if (self._router.length) {
-      self.emit('join', contact);
-      self.emit('connect', contact);
-    } else {
-      self.emit('leave', contact);
-      self.emit('disconnect', contact);
-    }
+    self._router.getSize(function(err, size) {
+      if(size) {
+        self.emit('join', contact);
+        self.emit('connect', contact);
+      } else {
+        self.emit('leave', contact);
+        self.emit('disconnect', contact);
+      }
+    });
   }
 
   this._router.on('add', checkRouterStatus);
-  this._router.on('remove', checkRouterStatus);
+  this._router.on('drop', checkRouterStatus);
 };
 
 /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -674,7 +674,7 @@ Router.prototype.getNearestContacts = function(key, limit, nodeID, callback) {
     callback(null, contacts);
   });
   } else {
-    this._log.warn("calling getNearestContacts synchronously is deprecated, supply callback to use async version")
+    this._log.warn('sync calling deprecated, use callback');
     return contacts;
   }
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -9,9 +9,10 @@ var constants = require('./constants');
 var utils = require('./utils');
 var Message = require('./message');
 var Logger = require('./logger');
-var Bucket = require('./bucket');
 var Contact = require('./contact');
 var Item = require('./item');
+var MemStore = require('kad-memstore');
+var Bucket = require('./bucket');
 
 /**
  * Represents a routing table of known {@link Contact}s; used by {@link Node}.
@@ -30,16 +31,10 @@ function Router(options) {
   }
 
   this._log = options.logger || new Logger(4);
-  this._buckets = {};
+  this._storage = options.storage || new MemStore();
   this._rpc = options.transport;
   this._self = this._rpc._contact;
   this._validator = options.validator;
-
-  Object.defineProperty(this, 'length', {
-    get: this._getSize.bind(this),
-    enumerable: false,
-    configurable: false
-  });
 }
 /**
  * Called when a value is returned from a lookup to validate it
@@ -101,63 +96,92 @@ Router.prototype.lookup = function(type, key, callback) {
  * the Router#length property
  * @private
  */
-Router.prototype._getSize = function() {
-  var total = 0;
-
-  for (var k in this._buckets) {
-    total += this._buckets[k].getSize();
-  }
-
-  return total;
+Router.prototype.getSize = function(callback) {
+  var self = this;
+  var size = 0;
+  this._storage.get('BUCKETS', function(err, result) {
+    if(err) {
+      callback(err);
+    } else {
+      async.each(result, function(index, cb) {
+        var bucket = new Bucket(index, self._storage);
+        bucket.load(function(err) {
+          if(err) {
+            cb(err);
+          } else {
+            size += bucket.getSize();
+            cb();
+          }
+        });
+      }, function(err) {
+        if(err) {
+          callback(err);
+        } else {
+          callback(null, size);
+        }
+      });
+    }
+  });
 };
 
 /**
  * Empties the routing table, clearing all known contacts
  */
 Router.prototype.empty = function() {
-  this._buckets = {};
-  this.emit('remove', this._self);
+  var self = this;
+  this._storage.get('BUCKETS', function(err, result) {
+    if(err) {
+      self.emit('remove', self._self);
+    } else {
+        async.each(result, function(index, callback) {
+          var bucket = new Bucket(index, self._storage);
+          bucket.empty(callback);
+        }, function() {
+          self._storage.del('BUCKETS', function() {
+            self.emit('remove', self._self);
+          });
+        });
+    }
+  });
 };
 
 /**
  * Removes the given contact from the routing table
  * @param {Contact} contact - The contact to drop from the router
- * @returns {Boolean} Operation succeeded (contact was in expected bucket)
+ * @param {Function} callback - Contact was in expected bucket
  */
-Router.prototype.removeContact = function(contact) {
+Router.prototype.removeContact = function(contact, callback) {
+  var self = this;
   var index = utils.getBucketIndex(this._self.nodeID, contact.nodeID);
-  var bucket = this._buckets[index];
-
   this._log.debug('removing contact %j', contact);
   assert(index < constants.B, 'Bucket index may not exceed B');
-
-  if (!bucket) {
-    return false;
-  }
-
-  bucket.removeContact(contact);
-  this.emit('shift', contact, bucket, bucket.indexOf(contact));
-
-  return true;
+  var bucket = new Bucket(index, this._storage);
+  async.waterfall([
+      bucket.load.bind(bucket),
+      bucket.removeContact.bind(bucket, contact),
+      bucket.save.bind(bucket),
+      self._storage.del.bind(self._storage, contact.nodeID),
+      function(cb) {
+        self.emit('drop', contact);
+        cb();
+      }
+  ], callback);
 };
 
 /**
  * Returns the {@link Contact} in the routing table by the given node ID
  * @param {String} nodeID - The nodeID of the {@link Contact} to return
- * @returns {Contact|null}
  */
-Router.prototype.getContactByNodeID = function(nodeID) {
-  for (var k in this._buckets) {
-    var contacts = this._buckets[k].getContactList();
-
-    for (var i = 0; i < contacts.length; i++) {
-      if (nodeID === contacts[i].nodeID) {
-        return contacts[i];
-      }
+Router.prototype.getContactByNodeID = function(nodeID, callback) {
+  var self = this;
+  this._storage.get(nodeID, function(err, result) {
+    if(err) {
+      callback(err, null);
+    } else {
+      var contact = self._rpc._createContact(result);
+      callback(null, contact);
     }
-  }
-
-  return null;
+  });
  };
 
 /**
@@ -427,23 +451,27 @@ Router.prototype._handleValueReturned = function(state, callback) {
  * @param {Router~refreshBeyondCallback} done - Called upon successful refresh
  */
 Router.prototype.refreshBucketsBeyondClosest = function(contacts, done) {
-  var bucketIndexes = Object.keys(this._buckets);
-  var leastBucket = _.min(bucketIndexes);
+  var self = this;
+  this._storage.get('BUCKETS', function(err, bucketIndexes) {
+    if(!err) {
+      var leastBucket = _.min(bucketIndexes);
 
-  function bucketFilter(index) {
-    return index >= leastBucket;
-  }
+      function bucketFilter(index) {
+        return index >= leastBucket;
+      }
 
-  var refreshBuckets = bucketIndexes.filter(bucketFilter);
-  var queue = async.queue(this.refreshBucket.bind(this), 1);
+      var refreshBuckets = bucketIndexes.filter(bucketFilter);
+      var queue = async.queue(self.refreshBucket.bind(self), 1);
 
-  this._log.debug('refreshing buckets farthest than closest known');
+      self._log.debug('refreshing buckets farthest than closest known');
 
-  refreshBuckets.forEach(function(index) {
-    queue.push(index);
+      refreshBuckets.forEach(function(index) {
+        queue.push(index);
+      });
+
+      done();
+    }
   });
-
-  done();
 };
 /**
  * This callback is called upon completion of
@@ -501,7 +529,9 @@ Router.prototype.findValue = function(key, callback) {
  */
 Router.prototype.findNode = function(nodeID, callback) {
   var self = this;
-
+  if(!callback) {
+    callback = function() {};
+  }
   this._log.debug('searching for nodes close to key %s', nodeID);
 
   this.lookup('NODE', nodeID, function(err, type, contacts) {
@@ -527,28 +557,28 @@ Router.prototype.findNode = function(nodeID, callback) {
  * @returns {Contact}
  */
 Router.prototype.updateContact = function(contact, callback) {
+  var self = this;
+  if(!callback) {
+    callback = function() {};
+  }
   var bucketIndex = utils.getBucketIndex(this._self.nodeID, contact.nodeID);
-
   this._log.debug('updating contact %j', contact);
   assert(bucketIndex < constants.B, 'Bucket index cannot exceed B');
-
-  if (!this._buckets[bucketIndex]) {
-    this._log.debug('creating new bucket for contact at index %d', bucketIndex);
-    this._buckets[bucketIndex] = new Bucket();
-  }
-
-  var bucket = this._buckets[bucketIndex];
-
   contact.seen();
-
-  if (bucket.hasContact(contact.nodeID)) {
-    this._moveContactToTail(contact, bucket, callback);
-  } else if (bucket.getSize() < constants.K) {
-    this._moveContactToHead(contact, bucket, callback);
-  } else {
-    this._pingContactAtHead(contact, bucket, callback);
-  }
-
+  var bucket = new Bucket(bucketIndex, this._storage);
+  async.series([
+    self._storage.put.bind(self._storage, contact.nodeID, contact),
+    bucket.load.bind(bucket),
+    bucket.loadContacts.bind(bucket)
+  ], function() {
+    if(bucket.hasContact(contact.nodeID)) {
+      self._moveContactToTail(contact, bucket, callback);
+    } else if(bucket.getSize() < constants.K) {
+      self._moveContactToHead(contact, bucket, callback);
+    } else {
+      self._pingContactAtHead(contact, bucket, callback);
+    }
+  });
   return contact;
 };
 /**
@@ -564,14 +594,21 @@ Router.prototype.updateContact = function(contact, callback) {
 * @param {Function} callback
 */
 Router.prototype._moveContactToTail = function(contact, bucket, callback) {
-  this._log.debug('contact already in bucket, moving to tail');
-  bucket.removeContact(contact);
-  bucket.addContact(contact);
-  this.emit('shift', contact, bucket, bucket.indexOf(contact));
-
-  if (callback) {
-    callback();
+  var self = this;
+  if(!callback) {
+    callback = function() {};
   }
+  this._log.debug('contact already in bucket, moving to tail');
+  async.waterfall([
+    bucket.removeContact.bind(bucket, contact),
+    bucket.addContact.bind(bucket),
+    self._storage.put.bind(self._storage, contact.nodeID),
+    bucket.save.bind(bucket),
+    function(cb) {
+      self.emit('shift', contact, bucket.index, bucket.indexOf(contact));
+      cb();
+    }
+  ], callback);
 };
 
 /**
@@ -582,13 +619,20 @@ Router.prototype._moveContactToTail = function(contact, bucket, callback) {
  * @param {Function} callback
  */
 Router.prototype._moveContactToHead = function(contact, bucket, callback) {
+  var self = this;
   this._log.debug('contact not in bucket, moving to head');
-  bucket.addContact(contact);
-  this.emit('add', contact, bucket, bucket.indexOf(contact));
-
-  if (callback) {
-    callback();
+  if(!callback) {
+    callback = function() {};
   }
+  async.waterfall([
+    bucket.addContact.bind(bucket, contact),
+    self._storage.put.bind(self._storage, contact.nodeID),
+    bucket.save.bind(bucket),
+    function(cb) {
+      self.emit('add', contact, bucket.index, bucket.indexOf(contact));
+      cb();
+    }
+  ], callback);
 };
 
 /**
@@ -607,23 +651,33 @@ Router.prototype._pingContactAtHead = function(contact, bucket, callback) {
   this._rpc.send(head, ping, function(err) {
     if (err) {
       self._log.debug('head contact did not respond, replacing with new');
-
       // NB: It's possible that the head contact has changed between pings
       // NB: timeout, so we need to make sure that we get the *most* stale
       // NB: contact.
-      head = bucket.getContact(0);
-
-      bucket.removeContact(head);
-      bucket.addContact(contact);
-      self.emit('drop', head, bucket, bucket.indexOf(head));
-      self.emit('add', contact, bucket, bucket.indexOf(contact));
+      bucket = new Bucket(bucket.index, self._storage);
+      async.waterfall([
+        bucket.getContact.bind(bucket, 0),
+        bucket.removeContact.bind(bucket),
+        function(contact, cb) {
+          self.emit('drop', contact);
+          cb();
+        },
+        bucket.load.bind(bucket),
+        bucket.loadContacts.bind(bucket),
+        bucket.addContact.bind(bucket, contact),
+        function(contact, cb) {
+          self.emit('add', contact, bucket.index, bucket.indexOf(contact));
+          cb();
+        }
+      ], callback);
     } else {
-      bucket.removeContact(head);
-      bucket.addContact(head);
-    }
-
-    if (callback) {
-      callback();
+      bucket = new Bucket(bucket.index, self._storage);
+      async.series([
+        bucket.load.bind(bucket),
+        bucket.loadContacts.bind(bucket),
+        bucket.removeContact.bind(bucket, head),
+        bucket.addContact.bind(bucket)
+      ], callback);
     }
   });
 };
@@ -658,24 +712,51 @@ Router.prototype.getNearestContacts = function(key, limit, nodeID, callback) {
     });
   }
 
-  addNearestFromBucket(this._buckets[index]);
-
-  while (contacts.length < limit && ascBucketIndex < constants.B) {
-    ascBucketIndex++;
-    addNearestFromBucket(this._buckets[ascBucketIndex]);
+  function createBucket(index, callback) {
+    var bucket = new Bucket(index, self._storage);
+    async.series([
+      bucket.load.bind(bucket),
+      bucket.loadContacts.bind(bucket),
+      function(cb) {
+        addNearestFromBucket(bucket);
+        cb();
+      }
+    ], callback);
   }
 
-  while (contacts.length < limit && descBucketIndex >= 0) {
-    descBucketIndex--;
-    addNearestFromBucket(this._buckets[descBucketIndex]);
-  }
-  if(callback) {
-  setImmediate(function() {
-    callback(null, contacts);
+  async.series([
+    createBucket.bind(null, index),
+    function(ascCallback) {
+      async.whilst(
+        function() {
+          return contacts.length < limit && ascBucketIndex < constants.B;
+        },
+        function(cb) {
+          createBucket(ascBucketIndex, cb);
+          ascBucketIndex++;
+        },
+        ascCallback
+      );
+    },
+    function(descCallback) {
+      async.whilst(
+        function() {
+          return contacts.length < limit && descBucketIndex >= 0;
+        },
+        function(cb) {
+          createBucket(descBucketIndex, cb);
+          descBucketIndex--;
+        },
+        descCallback
+      );
+    }
+  ], function(err) {
+    if(err) {
+      callback(err);
+    } else {
+      callback(null, contacts);
+    }
   });
-  } else {
-    return contacts;
-  }
 };
 
 /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -669,9 +669,14 @@ Router.prototype.getNearestContacts = function(key, limit, nodeID, callback) {
     descBucketIndex--;
     addNearestFromBucket(this._buckets[descBucketIndex]);
   }
+  if(callback) {
   setImmediate(function() {
     callback(null, contacts);
   });
+  } else {
+    this._log.warn("calling getNearestContacts synchronously is deprecated, supply callback to use async version")
+    return contacts;
+  }
 };
 
 /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -674,7 +674,6 @@ Router.prototype.getNearestContacts = function(key, limit, nodeID, callback) {
     callback(null, contacts);
   });
   } else {
-    this._log.warn('sync calling deprecated, use callback');
     return contacts;
   }
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -75,20 +75,18 @@ inherits(Router, events.EventEmitter);
  */
 Router.prototype.lookup = function(type, key, callback) {
   assert(['NODE', 'VALUE'].indexOf(type) !== -1, 'Invalid search type');
-
-  var state = this._createLookupState(type, key);
-
-  if (!state.closestNode) {
-    return callback(new Error('Not connected to any peers'));
-  }
-
-  state.closestNodeDistance = utils.getDistance(
-    state.hashedKey,
-    state.closestNode.nodeID
-  );
-
-  this._log.debug('performing network walk for %s %s', type, key);
-  this._iterativeFind(state, state.shortlist, callback);
+  var self = this;
+  this._createLookupState(type, key, function(err, state) {
+    if (!state.closestNode) {
+      return callback(new Error('Not connected to any peers'));
+    }
+    state.closestNodeDistance = utils.getDistance(
+      state.hashedKey,
+      state.closestNode.nodeID
+    );
+    self._log.debug('performing network walk for %s %s', type, key);
+    self._iterativeFind(state, state.shortlist, callback);
+  });
 };
 /**
  * This callback is called upon completion of {@link Router#lookup}
@@ -169,7 +167,7 @@ Router.prototype.getContactByNodeID = function(nodeID) {
  * @param {String} key - 160 bit key
  * @returns {Object} Lookup state machine
  */
-Router.prototype._createLookupState = function(type, key) {
+Router.prototype._createLookupState = function(type, key, callback) {
   var state = {
     type: type,
     key: key,
@@ -181,14 +179,16 @@ Router.prototype._createLookupState = function(type, key) {
     value: null,
     contactsWithoutValue: []
   };
-  state.shortlist = this.getNearestContacts(
+  this.getNearestContacts(
     key,
     state.limit,
-    this._self.nodeID
-  );
-  state.closestNode = state.shortlist[0];
-
-  return state;
+    this._self.nodeID,
+    function(err, shortlist) {
+        state.shortlist = shortlist;
+        state.closestNode = state.shortlist[0];
+        callback(err, state);
+    }
+    );
 };
 
 /**
@@ -635,7 +635,7 @@ Router.prototype._pingContactAtHead = function(contact, bucket, callback) {
  * @param {String} nodeID - Node ID to exclude from results
  * @returns {Array}
  */
-Router.prototype.getNearestContacts = function(key, limit, nodeID) {
+Router.prototype.getNearestContacts = function(key, limit, nodeID, callback) {
   var self = this;
   var contacts = [];
   var index = utils.getBucketIndex(this._self.nodeID, utils.createID(key));
@@ -669,8 +669,9 @@ Router.prototype.getNearestContacts = function(key, limit, nodeID) {
     descBucketIndex--;
     addNearestFromBucket(this._buckets[descBucketIndex]);
   }
-
-  return contacts;
+  setImmediate(function() {
+    callback(null, contacts);
+  });
 };
 
 /**

--- a/test/node.unit.js
+++ b/test/node.unit.js
@@ -361,7 +361,7 @@ describe('Node', function() {
       var node = KNode({
         transport: transports.UDP(AddressPortContact({
           address: '0.0.0.0',
-          port: 65522
+          port: 65524
         })),
         storage: storage,
         logger: new Logger(0)
@@ -636,7 +636,7 @@ describe('Node', function() {
       ).callsArgWith(1, null, []);
       var _getNearestContacts = sinon.stub(
         node._router, 'getNearestContacts'
-      ).returns([]);
+      ).callsArgWith(3, null, []);
       node._putValidatedKeyValue(
         Item('key', 'value', rpc._contact.nodeID),
         function() {

--- a/test/router.unit.js
+++ b/test/router.unit.js
@@ -147,15 +147,16 @@ describe('Router', function() {
         cb(new Error());
       });
       var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
-      var state = router._createLookupState('VALUE', 'foo');
-      state.shortlist.push(contact);
-      router._queryContact(state, contact, function() {
-        expect(state.shortlist).to.have.lengthOf(0);
-        _rpc.restore();
-        done();
-      });
+      var callback = function(err, state) {
+        state.shortlist.push(contact);
+        router._queryContact(state, contact, function() {
+          expect(state.shortlist).to.have.lengthOf(0);
+          _rpc.restore();
+          done();
+        });
+      };
+      router._createLookupState('VALUE', 'foo', callback);
     });
-
   });
 
   describe('#_handleFindResult', function() {
@@ -174,19 +175,21 @@ describe('Router', function() {
         cb(new Error());
       });
       var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
-      var state = router._createLookupState('VALUE', 'foo');
-      state.shortlist.push(contact);
-      state.closestNodeDistance = '00000000000000000001';
-      router._handleFindResult(state, {
-        result: {
-          nodes: []
-        },
-        id: utils.createID('test')
-      }, contact, function() {
-        expect(state.contactsWithoutValue).to.have.lengthOf(1);
-        _rpc.restore();
-        done();
-      });
+      var callback = function(err, state) {
+        state.shortlist.push(contact);
+        state.closestNodeDistance = '00000000000000000001';
+        router._handleFindResult(state, {
+          result: {
+            nodes: []
+          },
+          id: utils.createID('test')
+        }, contact, function() {
+          expect(state.contactsWithoutValue).to.have.lengthOf(1);
+          _rpc.restore();
+          done();
+        });
+      };
+      router._createLookupState('VALUE', 'foo', callback);
     });
 
     it('should remove contact from shortlist when JSON is bad', function(done) {
@@ -203,19 +206,21 @@ describe('Router', function() {
         cb(new Error());
       });
       var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
-      var state = router._createLookupState('VALUE', 'foo');
-      state.shortlist.push(contact);
-      state.closestNodeDistance = '00000000000000000001';
-      router._handleFindResult(state, {
-        result: {
-          item: 'BAD JSON'
-        },
-        id: utils.createID('test')
-      }, contact, function() {
-        expect(state.contactsWithoutValue).to.have.lengthOf(0);
-        _rpc.restore();
-        done();
-      });
+      var callback = function(err, state) {
+        state.shortlist.push(contact);
+        state.closestNodeDistance = '00000000000000000001';
+        router._handleFindResult(state, {
+          result: {
+            item: 'BAD JSON'
+          },
+          id: utils.createID('test')
+        }, contact, function() {
+          expect(state.contactsWithoutValue).to.have.lengthOf(0);
+          _rpc.restore();
+          done();
+        });
+      };
+      router._createLookupState('VALUE', 'foo', callback);
     });
 
     it('should remove contact from shortlist when invalid', function(done) {
@@ -235,21 +240,23 @@ describe('Router', function() {
         cb(new Error());
       });
       var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
-      var state = router._createLookupState('VALUE', 'foo');
-      state.shortlist.push(contact);
-      state.closestNodeDistance = '00000000000000000001';
-      var itemKey = utils.createID('beep');
-      var publisherKey = utils.createID('publisher');
-      var item = new Item(itemKey, 'boop', publisherKey);
-      router._handleFindResult(state, {
-        result: {
-          item: item
-        }
-      }, contact, function() {
-        expect(state.shortlist).to.have.lengthOf(0);
-        _rpc.restore();
-        done();
-      });
+      var callback = function(err, state) {
+        state.shortlist.push(contact);
+        state.closestNodeDistance = '00000000000000000001';
+        var itemKey = utils.createID('beep');
+        var publisherKey = utils.createID('publisher');
+        var item = new Item(itemKey, 'boop', publisherKey);
+        router._handleFindResult(state, {
+          result: {
+            item: item
+          }
+        }, contact, function() {
+          expect(state.shortlist).to.have.lengthOf(0);
+          _rpc.restore();
+          done();
+        });
+      };
+      router._createLookupState('VALUE', 'foo', callback);
     });
 
     it('should send key/value pair to validator', function(done) {
@@ -269,16 +276,21 @@ describe('Router', function() {
       var itemKey = utils.createID('foo');
       var publisherKey = utils.createID('publisher');
       var item = new Item(itemKey, 'boop', publisherKey);
-      var state = node._router._createLookupState('VALUE', 'foo');
-      var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
-      state.shortlist.push(contact);
-      state.closestNodeDistance = '00000000000000000001';
-      node._router._handleFindResult(state, {
-        result: {
-          item: item
-        },
-        id: utils.createID('test')
-      }, contact, expect.fail);
+      var callback = function(err, state) {
+        var contact = new AddressPortContact({
+          address: '0.0.0.0',
+          port: 1234
+        });
+        state.shortlist.push(contact);
+        state.closestNodeDistance = '00000000000000000001';
+        node._router._handleFindResult(state, {
+          result: {
+            item: item
+          },
+          id: utils.createID('test')
+        }, contact, expect.fail);
+      };
+      node._router._createLookupState('VALUE', 'foo', callback);
     });
 
     it('should set the closest node and distance to current', function(done) {
@@ -295,27 +307,31 @@ describe('Router', function() {
         })),
         logger: new Logger(0)
       });
-      var state = router._createLookupState('VALUE', 'foo');
-      var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
-      var _validate = sinon.stub(
-        router,
-        '_validateFindResult'
-      ).callsArg(3);
-      state.closestNode = '1';
-      router._handleFindResult(state, {
-        result: {
-          item: {}
-        },
-        id: utils.createID('test')
-      }, contact, function() {
-        _validate.restore();
-        expect(state.previousClosestNode).to.equal('1');
-        expect(state.closestNode).to.equal(contact);
-        expect(state.closestNodeDistance).to.equal('2');
-        done();
-      });
+      var callback = function(err, state) {
+        var contact = new AddressPortContact({
+            address: '0.0.0.0',
+            port: 1234
+        });
+        var _validate = sinon.stub(
+          router,
+          '_validateFindResult'
+        ).callsArg(3);
+        state.closestNode = '1';
+        router._handleFindResult(state, {
+          result: {
+            item: {}
+          },
+          id: utils.createID('test')
+        }, contact, function() {
+          _validate.restore();
+          expect(state.previousClosestNode).to.equal('1');
+          expect(state.closestNode).to.equal(contact);
+          expect(state.closestNodeDistance).to.equal('2');
+          done();
+        });
+      };
+      router._createLookupState('VALUE', 'foo', callback);
     });
-
   });
 
   describe('#_handleQueryResults', function() {
@@ -329,17 +345,19 @@ describe('Router', function() {
         storage: new FakeStorage(),
         logger: new Logger(0)
       });
-      var state = node._router._createLookupState(
+      var callback = function(err, state) {
+        state.shortlist = new Array(constants.K);
+        node._router._handleQueryResults(state, function(err, type, contacts) {
+          expect(contacts).to.equal(state.shortlist);
+          done();
+        });
+      };
+      node._router._createLookupState(
         'VALUE',
-        utils.createID('foo')
+        utils.createID('foo'),
+        callback
       );
-      state.shortlist = new Array(constants.K);
-      node._router._handleQueryResults(state, function(err, type, contacts) {
-        expect(contacts).to.equal(state.shortlist);
-        done();
-      });
     });
-
   });
 
   describe('#_handleValueReturned', function() {
@@ -356,24 +374,26 @@ describe('Router', function() {
       var _send = sinon.stub(node._router._rpc, 'send');
       var contact1 = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
       var contact2 = new AddressPortContact({ address: '0.0.0.0', port: 1235 });
-      var state = node._router._createLookupState(
-        'VALUE',
-        utils.createID('foo')
-      );
-      state.item = {
-        key: 'foo',
-        value: 'bar',
-        publisher: utils.createID('foo'),
-        timestamp: Date.now()
+      var callback = function(err, state) {
+        state.item = {
+          key: 'foo',
+          value: 'bar',
+          publisher: utils.createID('foo'),
+          timestamp: Date.now()
+        };
+        state.contactsWithoutValue = [contact1, contact2];
+        node._router._handleValueReturned(state, function() {
+          expect(_send.callCount).to.equal(1);
+          expect(_send.calledWith(contact1)).to.equal(true);
+          done();
+        });
       };
-      state.contactsWithoutValue = [contact1, contact2];
-      node._router._handleValueReturned(state, function() {
-        expect(_send.callCount).to.equal(1);
-        expect(_send.calledWith(contact1)).to.equal(true);
-        done();
-      });
+      node._router._createLookupState(
+        'VALUE',
+        utils.createID('foo'),
+        callback
+      );
     });
-
   });
 
   describe('#updateContact', function() {


### PR DESCRIPTION
This is a pre-requisite for implementing kad-fs with kad-telemetry.
The interface to kad-telemetry currently assumes that getNearestContacts directly returns
Currently kad-telemetry is implemented using file storage that is read in memory.
I would like to change this to use kad-fs interface which is async

Tests and linter pass on my local machine.