### PR TITLE
HTTP persistent connections and disabling nagling

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -7,8 +7,10 @@ var inherits = require('util').inherits;
 var http = require('http');
 var https = require('https');
 var RPC = require('../rpc');
-var httpagent = new http.Agent({keepAlive: true}); // enable http persistent connections
-var httpsagent = new https.Agent({keepAlive: true}); // enable https persistent connections
+
+// create agents to enable http persistent connections:
+var httpagent = new http.Agent({keepAlive: true});
+var httpsagent = new https.Agent({keepAlive: true});
 
 /**
  * Transport adapter that sends and receives messages over HTTP
@@ -28,7 +30,8 @@ function HTTPTransport(contact, options) {
   this._cors = options && !!options.cors;
   this._sslopts = options && options.ssl;
   this._protocol = this._sslopts ? https : http;
-  this._agent = this._sslopts ? httpsagent : httpagent; // assign the correct agent
+  // assign the correct agent based on the protocol:
+  this._agent = this._sslopts ? httpsagent : httpagent;
 
   assert(contact instanceof AddressPortContact, 'Invalid contact supplied');
   RPC.call(this, contact, options);
@@ -91,7 +94,8 @@ HTTPTransport.prototype._open = function(done) {
 
   // we should disable nagling as all of our response gets sent in one go:
   this._server.on('connection', function(socket) {
-    socket.setNoDelay(true); // disable the tcp nagle algorithm on the newly accepted socket
+    // disable the tcp nagle algorithm on the newly accepted socket:
+    socket.setNoDelay(true);
   });
 
   this._server.listen(this._contact.port, done);

--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -7,6 +7,8 @@ var inherits = require('util').inherits;
 var http = require('http');
 var https = require('https');
 var RPC = require('../rpc');
+var httpagent = new http.Agent({keepAlive: true}); // enable http persistent connections
+var httpsagent = new https.Agent({keepAlive: true}); // enable https persistent connections
 
 /**
  * Transport adapter that sends and receives messages over HTTP
@@ -26,7 +28,7 @@ function HTTPTransport(contact, options) {
   this._cors = options && !!options.cors;
   this._sslopts = options && options.ssl;
   this._protocol = this._sslopts ? https : http;
-  this._agent = new this._protocol.Agent({keepAlive: true}); // enable persistent connections
+  this._agent = this._sslopts ? httpsagent : httpagent; // assign the correct agent
 
   assert(contact instanceof AddressPortContact, 'Invalid contact supplied');
   RPC.call(this, contact, options);
@@ -87,6 +89,11 @@ HTTPTransport.prototype._open = function(done) {
     });
   });
 
+  // we should disable nagling as all of our response gets sent in one go:
+  this._server.on('connection', function(socket) {
+    socket.setNoDelay(true); // disable the tcp nagle algorithm on the newly accepted socket
+  });
+
   this._server.listen(this._contact.port, done);
 };
 
@@ -119,7 +126,6 @@ HTTPTransport.prototype._send = function(data, contact) {
 
   if (this._queuedResponses[parsed.id]) {
     this._queuedResponses[parsed.id].end(data);
-    this._queuedResponses[parsed.id].socket.destroy();
     delete this._queuedResponses[parsed.id];
     return;
   }
@@ -135,6 +141,8 @@ HTTPTransport.prototype._send = function(data, contact) {
     method: 'POST',
     agent: self._agent
   }, handleResponse);
+
+  req.setNoDelay(true); // disable the tcp nagle algorithm
 
   req.on('error', function() {
     self.receive(null);

--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -26,6 +26,7 @@ function HTTPTransport(contact, options) {
   this._cors = options && !!options.cors;
   this._sslopts = options && options.ssl;
   this._protocol = this._sslopts ? https : http;
+  this._agent = new this._protocol.Agent({keepAlive: true}); // enable persistent connections
 
   assert(contact instanceof AddressPortContact, 'Invalid contact supplied');
   RPC.call(this, contact, options);
@@ -131,7 +132,8 @@ HTTPTransport.prototype._send = function(data, contact) {
   var req = self._protocol.request({
     hostname: contact.address,
     port: contact.port,
-    method: 'POST'
+    method: 'POST',
+    agent: self._agent
   }, handleResponse);
 
   req.on('error', function() {

--- a/test/transports/http.unit.js
+++ b/test/transports/http.unit.js
@@ -65,7 +65,10 @@ describe('Transports/HTTP', function() {
         http: {
           createServer: function(onConnect) {
             onConnect(req, res);
-            return { listen: sinon.stub() };
+            return {
+              listen: sinon.stub(),
+              on: sinon.stub()
+            };
           }
         }
       });
@@ -88,7 +91,10 @@ describe('Transports/HTTP', function() {
         http: {
           createServer: function(onConnect) {
             onConnect(req, res);
-            return { listen: sinon.stub() };
+            return {
+              listen: sinon.stub(),
+              on: sinon.stub()
+            };
           }
         }
       });
@@ -201,6 +207,7 @@ describe('Transports/HTTP', function() {
       var emitter = new EventEmitter();
       var emitter2 = new EventEmitter();
       emitter2.end = sinon.stub();
+      emitter2.setNoDelay = sinon.stub();
 
       var _request = sinon.stub(
         rpc1._protocol,
@@ -347,6 +354,7 @@ describe('Transports/HTTP', function() {
     it('should pass null to handleMessage on request error', function(done) {
       var emitter = new EventEmitter();
       emitter.end = sinon.stub();
+      emitter.setNoDelay = sinon.stub();
       var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var recipient = new AddressPortContact({
         address: '127.0.0.1',
@@ -358,7 +366,9 @@ describe('Transports/HTTP', function() {
             return emitter;
           },
           createServer: function() {
-            return { listen: sinon.stub() };
+            return { listen: sinon.stub(),
+              on: sinon.stub()
+            };
           }
         }
       });


### PR DESCRIPTION
### Persistent Connections
My previous pull request #72 was broken as there was something still causing the server side to close the connection. I found [line 121 `this._queuedResponses[parsed.id].socket.destroy();`](https://github.com/kadtools/kad/blob/master/lib/transports/http.js#L121) was causing the sockets to close even when `Connection: keep-alive` header was set on both the client and server. Was there a purposeful reason for destroying the socket rather than letting the underlying http code handle the socket?

### Nagle Algorithm
For faster requests and responses we should disable the TCP Nagle Algorithm as all of our request and response data is written in one go, so there is no need to delay sending the packet.