### PR TITLE
distances in Kademlia are independent of the bucket size

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -41,6 +41,3 @@ module.exports = {
   ]
 
 };
-
-/** @constant {Number} BinB - Bytes for nodeID creation (derived from B) */
-module.exports.BinB = module.exports.B / 8;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -41,3 +41,6 @@ module.exports = {
   ]
 
 };
+
+/** @constant {Number} BinB - Number of bytes for nodeID creation (derived from constant B) */
+module.exports.BinB = module.exports.B / 8;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -42,5 +42,5 @@ module.exports = {
 
 };
 
-/** @constant {Number} BinB - Number of bytes for nodeID creation (derived from constant B) */
+/** @constant {Number} BinB - Bytes for nodeID creation (derived from B) */
 module.exports.BinB = module.exports.B / 8;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,7 @@ exports.createID = function(data) {
  * @returns {Buffer}
  */
 exports.hexToBuffer = function(hexString) {
-  var buf = new Buffer(constants.BinB);
+  var buf = new Buffer(constants.B / 8);
   buf.write(hexString, 0, 'hex');
   return buf;
 };
@@ -51,11 +51,11 @@ exports.getDistance = function(id1, id2) {
   assert(exports.isValidKey(id1), 'Invalid key supplied');
   assert(exports.isValidKey(id2), 'Invalid key supplied');
 
-  var distance = new Buffer(constants.BinB);
+  var distance = new Buffer(constants.B / 8);
   var id1Buf = exports.hexToBuffer(id1);
   var id2Buf = exports.hexToBuffer(id2);
 
-  for(var i = 0; i < constants.BinB; ++i) {
+  for(var i = 0; i < constants.B / 8; ++i) {
     distance[i] = id1Buf[i] ^ id2Buf[i];
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,7 @@ exports.createID = function(data) {
  * @returns {Buffer}
  */
 exports.hexToBuffer = function(hexString) {
-  var buf = new Buffer(constants.K);
+  var buf = new Buffer(constants.B);
   buf.write(hexString, 0, 'hex');
   return buf;
 };
@@ -51,11 +51,11 @@ exports.getDistance = function(id1, id2) {
   assert(exports.isValidKey(id1), 'Invalid key supplied');
   assert(exports.isValidKey(id2), 'Invalid key supplied');
 
-  var distance = new Buffer(constants.K);
+  var distance = new Buffer(constants.B);
   var id1Buf = exports.hexToBuffer(id1);
   var id2Buf = exports.hexToBuffer(id2);
 
-  for(var i = 0; i < constants.K; ++i) {
+  for(var i = 0; i < constants.B; ++i) {
     distance[i] = id1Buf[i] ^ id2Buf[i];
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,7 @@ exports.createID = function(data) {
  * @returns {Buffer}
  */
 exports.hexToBuffer = function(hexString) {
-  var buf = new Buffer(constants.B);
+  var buf = new Buffer(constants.BinB);
   buf.write(hexString, 0, 'hex');
   return buf;
 };
@@ -51,11 +51,11 @@ exports.getDistance = function(id1, id2) {
   assert(exports.isValidKey(id1), 'Invalid key supplied');
   assert(exports.isValidKey(id2), 'Invalid key supplied');
 
-  var distance = new Buffer(constants.B);
+  var distance = new Buffer(constants.BinB);
   var id1Buf = exports.hexToBuffer(id1);
   var id2Buf = exports.hexToBuffer(id2);
 
-  for(var i = 0; i < constants.B; ++i) {
+  for(var i = 0; i < constants.BinB; ++i) {
     distance[i] = id1Buf[i] ^ id2Buf[i];
   }
 


### PR DESCRIPTION
use the number of actual nodeID bits to compute the distance instead of the number of contacts hold in a bucket.

Please correct me if I'm wrong. If you assume bucket sizes of e.g. K=4, wouldn't this implicate that the maximum distance is 2^4-1 even though an address of B=160 bits would allow for distances up to 2^160-1?