### PR TITLE
increase time between keep alive packages

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -9,8 +9,8 @@ var https = require('https');
 var RPC = require('../rpc');
 
 // create agents to enable http persistent connections:
-var httpagent = new http.Agent({keepAlive: true});
-var httpsagent = new https.Agent({keepAlive: true});
+var httpagent = new http.Agent({keepAlive: true, keepAliveMsecs: 25000});
+var httpsagent = new https.Agent({keepAlive: true, keepAliveMsecs: 25000});
 
 /**
  * Transport adapter that sends and receives messages over HTTP


### PR DESCRIPTION
default value is 1000msec, which is extrem conservative.

In my special case, in use with storj in a multi host / multi node environment there is 98% of traffic keep alive traffic, if nodes are in idle mode, this mass is a problem for cheap home router, which have a limited routing capacity measured in pps (packets-per-second)  and not limited by bandwidth.